### PR TITLE
Fix first-build pack failure: MakeDir pack dir + net10.0 nuspec

### DIFF
--- a/bamdb/bamdb.csproj
+++ b/bamdb/bamdb.csproj
@@ -74,4 +74,7 @@
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 
+  <Target Name="EnsureIntermediatePackDir" BeforeTargets="GenerateNuspec">
+    <MakeDir Directories="$(PublishDir)" />
+  </Target>
 </Project>

--- a/bamdb/bamdb.nuspec
+++ b/bamdb/bamdb.nuspec
@@ -6,7 +6,7 @@
     <description>bamdb</description>
   </metadata>
   <files>
-    <file src="_._" target="lib/net7.0" />
-    <file src="$publishdir$\net7.0\**\*" target="tools/net7.0" />
+    <file src="_._" target="lib/net10.0" />
+    <file src="$publishdir$\net10.0\**\*" target="tools/net10.0" />
   </files>
 </package>


### PR DESCRIPTION
## Description
TL;DR Adds an `EnsureIntermediatePackDir` target (MakeDir on `$(PublishDir)`) and updates `bamdb.nuspec` from stale `net7.0` segments to `net10.0`, so the first build on a machine with no pre-existing `~/.bam` directory succeeds.

bamdb is the only nuspec-packing project in bamtk.sln with `GeneratePackageOnBuild`, so this was the actual clean-machine build blocker (defect 5 of the fresh-clone issue). The nuspec's `$publishdir$\net7.0\**\*` glob pointed at a TFM the project hasn't targeted since the net10 upgrade, and nothing created the directory.

part of BryanApellanes/bamtk#45

🤖 Generated with [Claude Code](https://claude.com/claude-code)